### PR TITLE
ci: add asset build step to workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Build assets
+        run: npm run build
+
       - name: Generate application key
         run: php artisan key:generate
 


### PR DESCRIPTION
## What does this PR do?

This PR enhances our CI workflow (`laravel.yml`) by adding two essential new steps to the test job: installing front-end dependencies (`npm install`) and compiling assets (`npm run build`).

## Why is this change necessary?

This change is crucial for two important technical reasons:

1.  **Front-end Validation:** The build step acts as a sanity check, ensuring that front-end code with syntax errors is caught before being merged into `main`.
2.  **Enabling Feature Tests:** Our tests that render Vite-powered views depend on the manifest file (`public/build/manifest.json`). This file is generated during the `npm run build` step, and without it, these tests would fail in the CI environment.

Additionally, this aligns our CI environment with the build process that will be used in production.

## How was the solution implemented?

In the `.github/workflows/laravel.yml` file, two new steps were added to the `test` job, executed right after the code checkout:

-   **Install npm dependencies:**
    ```yaml
    - name: Install npm dependencies
      run: npm install
    ```
-   **Build assets:**
    ```yaml
    - name: Build assets
      run: npm run build
    ```

## How to test?

This change is validated by observing the CI pipeline execution in this Pull Request itself.

1.  Navigate to the **"Checks"** or **"Actions"** tab at the bottom of this page.
2.  **Expected Result:** The "Laravel CI" workflow should run and now contain two new steps: **"Install npm dependencies"** and **"Build assets"**.
3.  **Final Expected Result:** Both new steps, as well as the entire workflow, should complete successfully (marked with a green check icon ✅).