### PR TITLE
refactor(deploy): move application caching from image build to deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,11 @@ jobs:
             echo "==> Running database migrations..."
             docker compose -f docker-compose.prod.yml exec app_playce php artisan migrate --force
 
+            echo "==> Setting cache..."
+            docker compose -f docker-compose.prod.yml exec app_playce php artisan view:cache
+            docker compose -f docker-compose.prod.yml exec app_playce php artisan route:cache
+            docker compose -f docker-compose.prod.yml exec app_playce php artisan config:cache
+
             echo "==> Cleaning up unused Docker resources..."
             docker image prune -af
             docker container prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN composer install --no-interaction --no-scripts --no-dev --optimize-autoloade
 
 COPY . .
 
-RUN php artisan route:cache && \
-    php artisan view:cache
-
 FROM node:20-alpine AS asset_builder
 
 WORKDIR /app


### PR DESCRIPTION
## What does this PR do?

This PR refactors our deployment strategy by changing where and when the Laravel application caches (`config`, `route`, `view`) are generated.

The change consists of removing the caching commands from the `Dockerfile` and moving them into our `deploy.yml` workflow, so they are run on the production server during each deployment.

## Why is this change necessary?

Generating caches during the image build (`docker build`) is a problematic pattern. It "freezes" configurations and environment variables (like `APP_URL`) that are present in the build environment. When the container runs in production with different variables, these stale caches can cause subtle but critical bugs, such as incorrectly generated URLs in emails, APIs, or application links.

By moving the caching commands to the deployment script, we ensure the caches are always generated on the target server, using the correct, live production environment variables. This makes our Docker image more environment-agnostic and the entire deployment process more robust and reliable.

## How was the solution implemented?

1.  **In the `Dockerfile`:** The `RUN php artisan route:cache` and `RUN php artisan view:cache` commands were **removed**. The image is now built without any application caches.
2.  **In `deploy.yml`:** The `php artisan config:cache`, `route:cache`, and `view:cache` commands were **added** to the SSH deployment script. They run right after the `docker compose up` command, ensuring the application container is already running with the correct production environment variables.