### PR TITLE
feat(dev-env): add 'up' and 'down' commands to local script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To ensure that changes to the `Dockerfile`, `docker-compose.*.yml`, or other inf
     ```
 2.  To build, start, and initialize the entire environment, run a single command in your terminal:
     ```bash
-    ./local.sh
+    bash local.sh up
     ```
 3.  The script will:
     * Stop and remove any old containers. 
@@ -32,5 +32,5 @@ To ensure that changes to the `Dockerfile`, `docker-compose.*.yml`, or other inf
 ### Shutting Down the Environment
 To stop and remove the containers and volumes, use the following command:
 ```bash
-docker compose -f docker-compose.prod.yml -f docker-compose.local.prod.yml down -v
+bash local.sh down
 ```

--- a/local.sh
+++ b/local.sh
@@ -6,17 +6,34 @@ export HOST_UID=$(id -u)
 # shellcheck disable=SC2155
 export HOST_GID=$(id -g)
 
-docker compose -f docker-compose.prod.yml -f docker-compose.local.prod.yml down -v
+COMMAND=${1:-up}
 
-docker compose -f docker-compose.prod.yml -f docker-compose.local.prod.yml up -d --build
+DC="docker compose -f docker-compose.prod.yml -f docker-compose.local.prod.yml"
 
-echo "Waiting for the database to be healthy..."
+if [ "$COMMAND" = "down" ]; then
+    echo "==> Stopping and removing containers and volumes..."
+    $DC down -v
+    echo "==> Local environment stopped."
 
-# shellcheck disable=SC1083
-while [ "$(docker inspect -f {{.State.Health.Status}} mysql_playce)" != "healthy" ]; do
-    echo -n "."
-    sleep 3
-done
+elif [ "$COMMAND" = "up" ]; then
+    echo "==> Starting local environment (this may take a while on the first run)..."
+    $DC down -v
+    $DC up -d --build
 
-docker compose -f docker-compose.prod.yml -f docker-compose.local.prod.yml \
-    exec app_playce php artisan migrate
+    echo "==> Waiting for the database to be ready..."
+    # shellcheck disable=SC1083
+    while [ "$(docker inspect -f {{.State.Health.Status}} mysql_playce)" != "healthy" ]; do
+        echo -n "."
+        sleep 3
+    done
+    echo
+
+    echo "==> Running migrations..."
+    $DC exec app_playce php artisan migrate --force
+    echo "==> Local environment is ready at http://localhost"
+
+else
+    echo "Unknown command: $COMMAND"
+    echo "Usage: ./local.sh [up|down]"
+    exit 1
+fi


### PR DESCRIPTION
## What does this PR do?

This PR refactors our `local.sh` script, turning it into a management tool for the local development environment lifecycle.
It now accepts the `up` and `down` subcommands to centralize common operations for starting and stopping the stack.

## Why is this change necessary?

Previously, we had a script to **start** the environment, but no standardized and simple command to **stop and clean it up**.
This required developers to manually run longer `docker compose` commands, which could lead to mistakes or incomplete removal of volumes.

By adding a `down` command symmetrical to `up`, we create a more intuitive and complete usage experience, improving the developer’s daily workflow.

## How was the solution implemented?

* The `local.sh` script was refactored to interpret the first argument as a subcommand (using a `case` structure).
* **`up` command:** Encapsulates all the existing logic: build and start the containers, wait for the database, and run migrations. This is the default behavior if no command is provided.
* **`down` command:** Implements the new functionality to safely stop and remove containers and associated anonymous volumes using `docker compose down -v`.
* **Documentation:** The `CONTRIBUTING.md` file was updated to reflect the new usage pattern of the script with subcommands.

## How to test?

Validation consists of testing each new subcommand and the script’s default behavior.

**Prerequisites:** Ensure that any previous environment is stopped (you can run `bash local.sh down` if the branch is already updated).

### Step 1: Test the `up` command

1. From the project root, run: `bash local.sh up`
2. **Expected Result:** The full application stack should start, migrations should run, and the site should be accessible at `http://localhost:8000`. Check with `docker ps` that the containers are running.

### Step 2: Test the `down` command

1. After successfully completing Step 1, run: `bash local.sh down`
2. **Expected Result:** The script should finish without errors. Running `docker ps` again should show **no project containers** listed.

### Step 3: Test the Default Behavior

1. After Step 2, run the script with no arguments: `bash local.sh`
2. **Expected Result:** Behavior should be identical to Step 1, bringing the full stack up again.

### Step 4: Review Documentation

1. Read the changes in the `CONTRIBUTING.md` file.
2. **Expected Result:** The instructions should be clear and correctly explain the usage of the new `up` and `down` commands.