### PR TITLE
feat(worker): add worker service for queue processing

### DIFF
--- a/docker-compose.local.prod.yml
+++ b/docker-compose.local.prod.yml
@@ -12,6 +12,23 @@ services:
     networks:
       - proxy
 
+  worker_playce:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - UID=${HOST_UID}
+        - GID=${HOST_GID}
+    user: "${HOST_UID}:${HOST_GID}"
+    restart: no
+    depends_on:
+      mysql:
+        condition: service_healthy
+    container_name: worker_playce
+    networks:
+      - proxy
+    command: php artisan queue:work --sleep=3 --tries=3
+
   nginx_playce:
     restart: no
     ports:
@@ -36,7 +53,12 @@ services:
       start_period: 30s
     networks:
       - proxy
+    volumes:
+      - mysql_data:/var/lib/mysql
 
 networks:
   proxy:
     external: true
+
+volumes:
+  mysql_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,18 @@ services:
     networks:
       - proxy
 
+  worker_playce:
+    image: ghcr.io/devc4rlos/playce:latest
+    container_name: worker_playce
+    restart: unless-stopped
+    volumes:
+      - ./.env:/var/www/.env
+      - ./storage:/var/www/storage
+      - app_files:/var/www
+    networks:
+      - proxy
+    command: php artisan queue:work --sleep=3 --tries=3
+
   nginx_playce:
     image: nginx:stable-alpine
     container_name: nginx_playce

--- a/local.sh
+++ b/local.sh
@@ -18,7 +18,8 @@ if [ "$COMMAND" = "down" ]; then
 elif [ "$COMMAND" = "up" ]; then
     echo "==> Starting local environment (this may take a while on the first run)..."
     $DC down -v
-    $DC up -d --build
+
+    $DC up -d --build mysql nginx_playce app_playce
 
     echo "==> Waiting for the database to be ready..."
     # shellcheck disable=SC1083
@@ -30,6 +31,10 @@ elif [ "$COMMAND" = "up" ]; then
 
     echo "==> Running migrations..."
     $DC exec app_playce php artisan migrate --force
+
+    echo "==> Starting the worker..."
+    $DC up -d --build worker_playce
+
     echo "==> Local environment is ready at http://localhost"
 
 else


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `worker` service to our architecture, enabling asynchronous processing of background jobs through Laravel's queue system.

Additionally, it configures a named volume for the MySQL service to ensure data persistence in the local development environment across sessions.

## Why is this change necessary?

* **Worker for Queued Jobs:** As the application grows, certain tasks (like sending emails, processing reports, or API integrations) can become too slow to execute during a web request. Offloading these tasks to a background `worker` results in a much faster and more responsive user experience.
* **Local Data Persistence:** With the addition of background jobs that might modify the database, it's crucial that our development data is not lost every time the environment is restarted. The named volume for MySQL solves the problem of data loss when running `bash local.sh down`, making debugging and development much more efficient.

## How was the solution implemented?

* **Worker Service:** A new service named `worker_playce` was added to our `docker-compose` files. This service uses the same application image but runs the `php artisan queue:work` command to listen for and process jobs from the queue.
* **Orchestration:** The `local.sh` script was adjusted to start the `worker_playce` service only **after** the database migrations have successfully run, ensuring the worker only operates when the database schema is ready.
* **Persistent Volume:** A Docker named volume, `mysql_data`, was configured for the `mysql` service in the `docker-compose.local.prod.yml` file, mapping the MySQL data to a persistent location on the host machine.